### PR TITLE
Returncode fix

### DIFF
--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -109,7 +109,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        sh -c {test_command}
+                        sh -o errexit -c {test_command}
                         popd
                     )
                     # exit if tests failed

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -124,7 +124,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         echo "sh exit code: $?"
                         popd
                     )
-                    echo "subshell exit code: $?"
                     if [ $? -ne 0 ]; then
                       exit 1;
                     fi

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -57,6 +57,9 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             mkdir /output
             cd /project
 
+
+            echo 'AAA'
+
             set -o
 
             {environment_exports}
@@ -97,7 +100,12 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                     # run the tests in a subshell to keep that `activate`
                     # script from polluting the env
                     (
+                        echo "before"
+                        set -o
+
                         set -o errexit
+                        echo "after"
+                        set -o
                         source "$venv_dir/bin/activate"
 
                         echo "Running tests using `which python`"

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -112,6 +112,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         sh -o errexit -c {test_command}
                         popd
                     )
+                    # exit if tests failed
                     if [ $? -ne 0 ]; then
                       exit 1;
                     fi

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -97,6 +97,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                     # run the tests in a subshell to keep that `activate`
                     # script from polluting the env
                     (
+                        set -o errexit
                         source "$venv_dir/bin/activate"
 
                         echo "Running tests using `which python`"

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -112,9 +112,13 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         sh -o errexit -c {test_command}
                         popd
                     )
-                    if [ $? -ne 0 ]; then
-                      exit 1;
-                    fi
+                    exit_code=$?
+
+                    echo "I am reached even though I shouldn't be"
+
+                    #if [ $? -ne 0 ]; then
+                    #  exit 1;
+                    #fi
 
                     # clean up
                     rm -rf "$venv_dir"

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -57,8 +57,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             mkdir /output
             cd /project
 
-            test_retcode=0
-
             {environment_exports}
 
             for PYBIN in {pybin_paths}; do
@@ -114,7 +112,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         sh -c {test_command}
                         popd
                     )
-                    test_retcode=$(( $test_retcode || $? ))
 
                     # clean up
                     rm -rf "$venv_dir"
@@ -124,8 +121,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                 mv "$delocated_wheel" /output
                 chown {uid}:{gid} "/output/$(basename "$delocated_wheel")"
             done
-
-            exit $test_retcode
         '''.format(
             pybin_paths=' '.join(c.path+'/bin' for c in platform_configs),
             test_requires=' '.join(test_requires),

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -121,9 +121,10 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         # Run the tests from a different directory
                         pushd $HOME
                         sh -o errexit -c {test_command}
-                        echo $?
+                        echo "sh exit code: $?"
                         popd
                     )
+                    echo "subshell exit code: $?"
 
                     # clean up
                     rm -rf "$venv_dir"

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -111,10 +111,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         pushd $HOME
                         sh -o errexit -c {test_command}
                         popd
-                    )
-                    exit_code=$?
-
-                    echo "I am reached even though I shouldn't be"
+                    ) || false
 
                     #if [ $? -ne 0 ]; then
                     #  exit 1;

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -57,6 +57,8 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             mkdir /output
             cd /project
 
+            set -o
+
             {environment_exports}
 
             for PYBIN in {pybin_paths}; do

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -120,7 +120,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        sh -o errexit -c {test_command}
+                        {test_command}
                         echo "sh exit code: $?"
                         popd
                     )

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -111,11 +111,10 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         pushd $HOME
                         sh -o errexit -c {test_command}
                         popd
-                    ) || false
-
-                    #if [ $? -ne 0 ]; then
-                    #  exit 1;
-                    #fi
+                    )
+                    if [ $? -ne 0 ]; then
+                      exit 1;
+                    fi
 
                     # clean up
                     rm -rf "$venv_dir"

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -120,7 +120,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        {test_command}
+                        {test_command_bare}
                         echo "sh exit code: $?"
                         popd
                     )
@@ -138,8 +138,10 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             pybin_paths=' '.join(c.path+'/bin' for c in platform_configs),
             test_requires=' '.join(test_requires),
             test_extras=test_extras,
-            test_command=prepare_command(test_command, project='/project') if test_command else ''
-            ,
+            test_command=shlex_quote(
+                prepare_command(test_command, project='/project') if test_command else ''
+            ),
+            test_command_bare=prepare_command(test_command, project='/project') if test_command else '',
             before_build=shlex_quote(
                 prepare_command(before_build, project='/project') if before_build else ''
             ),

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -121,6 +121,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                         # Run the tests from a different directory
                         pushd $HOME
                         sh -o errexit -c {test_command}
+                        echo $?
                         popd
                     )
 

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -115,8 +115,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        sh -o errexit -c {test_command}
-                        echo "sh exit code: $?"
+                        sh -c {test_command}
                         popd
                     )
                     if [ $? -ne 0 ]; then

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -109,7 +109,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        sh -c {test_command}
+                        sh -o errexit -c {test_command}
                         popd
                     )
                     if [ $? -ne 0 ]; then

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -57,11 +57,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             mkdir /output
             cd /project
 
-
-            echo 'AAA'
-
-            set -o
-
             {environment_exports}
 
             for PYBIN in {pybin_paths}; do

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -120,11 +120,14 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        {test_command_bare}
+                        sh -o errexit -c {test_command}
                         echo "sh exit code: $?"
                         popd
                     )
                     echo "subshell exit code: $?"
+                    if [ $? -ne 0 ]; then
+                      exit 1;
+                    fi
 
                     # clean up
                     rm -rf "$venv_dir"
@@ -141,7 +144,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             test_command=shlex_quote(
                 prepare_command(test_command, project='/project') if test_command else ''
             ),
-            test_command_bare=prepare_command(test_command, project='/project') if test_command else '',
             before_build=shlex_quote(
                 prepare_command(before_build, project='/project') if before_build else ''
             ),

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -111,7 +111,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        sh -c {test_command}
+                        sh -o errexit -c {test_command}
                         popd
                     )
 

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -95,12 +95,6 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
                     # run the tests in a subshell to keep that `activate`
                     # script from polluting the env
                     (
-                        echo "before"
-                        set -o
-
-                        set -o errexit
-                        echo "after"
-                        set -o
                         source "$venv_dir/bin/activate"
 
                         echo "Running tests using `which python`"

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -138,9 +138,8 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
             pybin_paths=' '.join(c.path+'/bin' for c in platform_configs),
             test_requires=' '.join(test_requires),
             test_extras=test_extras,
-            test_command=shlex_quote(
-                prepare_command(test_command, project='/project') if test_command else ''
-            ),
+            test_command=prepare_command(test_command, project='/project') if test_command else ''
+            ,
             before_build=shlex_quote(
                 prepare_command(before_build, project='/project') if before_build else ''
             ),

--- a/cibuildwheel/linux.py
+++ b/cibuildwheel/linux.py
@@ -109,7 +109,7 @@ def build(project_dir, output_dir, test_command, test_requires, test_extras, bef
 
                         # Run the tests from a different directory
                         pushd $HOME
-                        sh -o errexit -c {test_command}
+                        sh -c {test_command}
                         popd
                     )
                     # exit if tests failed


### PR DESCRIPTION
With this PR the entire bash script exits whenever the test command fails.

* ``sh -o errexit -c {test_command}`` adds the ``errexit`` flag in case the test command contains chained statements (e.g. ``./run_tests.sh ; true``).
* The if statement seems the cleanest way of testing the exit status of the subshell. Chaining with ``|| false`` did not work reliably.